### PR TITLE
Write `length` on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "bare-bundle": "^1.1.2",
+    "compact-encoding": "^2.15.0",
     "drive-bundler": "^1.3.2",
     "fs-native-extensions": "^1.2.0",
     "localdrive": "^1.9.0",


### PR DESCRIPTION
Alternatively, we could write the entire `checkout` struct to a `checkout` file.